### PR TITLE
feat: add Open Graph images for social sharing previews

### DIFF
--- a/src/app/brief/[id]/page.tsx
+++ b/src/app/brief/[id]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import CivicBrief from '@/components/CivicBrief';
 import type { CivicContent, FeedbackType } from '@/lib/types';
@@ -64,6 +65,56 @@ const MOCK_TRANSLATIONS: Record<string, { headline: string; content: CivicConten
 
 interface PageProps {
   params: Promise<{ id: string }>;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { id } = await params;
+
+  if (id === 'demo' || id === 'test-id') {
+    return {
+      title: 'Demo Brief | Civic Brief',
+      description: MOCK_BRIEF.headline,
+      openGraph: {
+        title: `${MOCK_BRIEF.headline} | Civic Brief`,
+        description: MOCK_BRIEF.content.what_changed,
+      },
+    };
+  }
+
+  try {
+    const { getServerClient } = await import('@/lib/supabase');
+    const db = getServerClient();
+
+    const { data: brief } = await db
+      .from('briefs')
+      .select('headline, summary, content')
+      .eq('id', id)
+      .eq('is_published', true)
+      .maybeSingle();
+
+    if (brief) {
+      const headline = brief.headline || 'Civic Brief';
+      const description =
+        brief.summary ||
+        (brief.content as CivicContent)?.what_changed ||
+        'A civic brief summarizing a government document.';
+      return {
+        title: `${headline} | Civic Brief`,
+        description,
+        openGraph: {
+          title: `${headline} | Civic Brief`,
+          description,
+        },
+      };
+    }
+  } catch {
+    // Supabase not configured; fall through to defaults
+  }
+
+  return {
+    title: 'Civic Brief',
+    description: 'A civic brief summarizing a government document.',
+  };
 }
 
 async function getBrief(id: string) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import AuthButton from '@/components/AuthButton';
 import './globals.css';
 
 export const metadata: Metadata = {
+  metadataBase: new URL('https://civic-brief.vercel.app'),
   title: 'Civic Brief',
   description:
     'Your government, in your language, in plain language. Open-source civic intelligence for every community.',
@@ -12,6 +13,10 @@ export const metadata: Metadata = {
     description:
       'Government documents go in. Plain-language civic briefs come out. In the languages your community actually speaks.',
     type: 'website',
+    siteName: 'Civic Brief',
+  },
+  twitter: {
+    card: 'summary_large_image',
   },
 };
 

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,151 @@
+import { ImageResponse } from 'next/og';
+
+export const runtime = 'edge';
+export const alt = 'Civic Brief: Plain language for public power.';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default async function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+          background: '#fcfaf7',
+          position: 'relative',
+        }}
+      >
+        {/* Top accent bar */}
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            height: '6px',
+            background: '#b44d12',
+          }}
+        />
+
+        {/* Subtle vertical lines for civic feel */}
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: '80px',
+            width: '1px',
+            height: '100%',
+            background: 'rgba(30, 58, 95, 0.06)',
+          }}
+        />
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            right: '80px',
+            width: '1px',
+            height: '100%',
+            background: 'rgba(30, 58, 95, 0.06)',
+          }}
+        />
+
+        {/* Content */}
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            padding: '0 120px',
+          }}
+        >
+          <div
+            style={{
+              fontSize: '72px',
+              fontWeight: 700,
+              color: '#1e3a5f',
+              fontFamily: 'Georgia, serif',
+              lineHeight: 1.1,
+              marginBottom: '24px',
+            }}
+          >
+            Civic Brief
+          </div>
+          <div
+            style={{
+              fontSize: '28px',
+              fontWeight: 400,
+              color: '#1b1b1f',
+              opacity: 0.65,
+              fontFamily: 'sans-serif',
+              lineHeight: 1.4,
+            }}
+          >
+            Plain language for public power.
+          </div>
+
+          {/* Divider */}
+          <div
+            style={{
+              width: '80px',
+              height: '3px',
+              background: '#b44d12',
+              marginTop: '40px',
+              marginBottom: '40px',
+              borderRadius: '2px',
+            }}
+          />
+
+          <div
+            style={{
+              fontSize: '18px',
+              fontWeight: 400,
+              color: '#1b1b1f',
+              opacity: 0.45,
+              fontFamily: 'sans-serif',
+              textAlign: 'center',
+              lineHeight: 1.5,
+              maxWidth: '600px',
+            }}
+          >
+            Government documents go in. Civic briefs come out. In the languages your community speaks.
+          </div>
+        </div>
+
+        {/* Bottom bar */}
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            height: '48px',
+            background: '#1e3a5f',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <div
+            style={{
+              fontSize: '14px',
+              fontWeight: 400,
+              color: 'rgba(252, 250, 247, 0.7)',
+              fontFamily: 'sans-serif',
+              letterSpacing: '0.05em',
+            }}
+          >
+            civic-brief.vercel.app
+          </div>
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+    }
+  );
+}

--- a/src/app/showcase/[scenario]/page.tsx
+++ b/src/app/showcase/[scenario]/page.tsx
@@ -15,6 +15,11 @@ export async function generateMetadata({ params }: PageProps) {
   return {
     title: `${config.title} | Civic Brief Showcase`,
     description: config.narrative,
+    openGraph: {
+      title: `${config.title} | Civic Brief Showcase`,
+      description: config.narrative,
+      siteName: 'Civic Brief',
+    },
   };
 }
 

--- a/src/app/showcase/opengraph-image.tsx
+++ b/src/app/showcase/opengraph-image.tsx
@@ -1,0 +1,174 @@
+import { ImageResponse } from 'next/og';
+
+export const runtime = 'edge';
+export const alt = 'Civic Brief Showcase: Five Stories. Five Communities.';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default async function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+          background: '#fcfaf7',
+          position: 'relative',
+        }}
+      >
+        {/* Top accent bar */}
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            height: '6px',
+            background: '#b44d12',
+          }}
+        />
+
+        {/* Content */}
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            padding: '0 120px',
+          }}
+        >
+          {/* Small label */}
+          <div
+            style={{
+              fontSize: '16px',
+              fontWeight: 600,
+              color: '#b44d12',
+              fontFamily: 'sans-serif',
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase' as const,
+              marginBottom: '20px',
+            }}
+          >
+            Civic Brief Showcase
+          </div>
+
+          <div
+            style={{
+              fontSize: '56px',
+              fontWeight: 700,
+              color: '#1e3a5f',
+              fontFamily: 'Georgia, serif',
+              lineHeight: 1.15,
+              marginBottom: '28px',
+              textAlign: 'center',
+            }}
+          >
+            Five Stories. Five Communities.
+          </div>
+
+          {/* Divider */}
+          <div
+            style={{
+              width: '60px',
+              height: '3px',
+              background: '#b44d12',
+              marginBottom: '28px',
+              borderRadius: '2px',
+            }}
+          />
+
+          <div
+            style={{
+              fontSize: '20px',
+              fontWeight: 400,
+              color: '#1b1b1f',
+              opacity: 0.55,
+              fontFamily: 'sans-serif',
+              textAlign: 'center',
+              lineHeight: 1.5,
+              maxWidth: '640px',
+            }}
+          >
+            Real government documents from across the US, turned into plain-language civic briefs anyone can understand.
+          </div>
+
+          {/* City dots */}
+          <div
+            style={{
+              display: 'flex',
+              gap: '32px',
+              marginTop: '40px',
+              alignItems: 'center',
+            }}
+          >
+            {['Philadelphia', 'Atlanta', 'Chicago', 'Seattle', 'Federal'].map(
+              (city) => (
+                <div
+                  key={city}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '8px',
+                  }}
+                >
+                  <div
+                    style={{
+                      width: '8px',
+                      height: '8px',
+                      borderRadius: '50%',
+                      background: '#1e3a5f',
+                    }}
+                  />
+                  <div
+                    style={{
+                      fontSize: '14px',
+                      color: '#1b1b1f',
+                      opacity: 0.5,
+                      fontFamily: 'sans-serif',
+                    }}
+                  >
+                    {city}
+                  </div>
+                </div>
+              )
+            )}
+          </div>
+        </div>
+
+        {/* Bottom bar */}
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            height: '48px',
+            background: '#1e3a5f',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <div
+            style={{
+              fontSize: '14px',
+              fontWeight: 400,
+              color: 'rgba(252, 250, 247, 0.7)',
+              fontFamily: 'sans-serif',
+              letterSpacing: '0.05em',
+            }}
+          >
+            civic-brief.vercel.app/showcase
+          </div>
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+    }
+  );
+}


### PR DESCRIPTION
## Summary
- Add default OG image (1200x630) with Civic Brief branding
- Add showcase-specific OG image
- Add `metadataBase`, `og:site_name`, `twitter:card` to layout
- Add `generateMetadata` to brief detail page for per-brief OG tags
- Enhance showcase detail metadata with OpenGraph fields

## Why
Shared links on Twitter, LinkedIn, WhatsApp, and Slack currently show blank previews. This makes the live demo look unprofessional when shared for Mozilla evaluation or community outreach.

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Deploy to Vercel preview, test OG images with https://www.opengraph.xyz/
- [ ] Verify default image at /opengraph-image
- [ ] Verify showcase image at /showcase/opengraph-image