### PR TITLE
fix: rename GOOGLE_GENERATIVE_AI_KEY to canonical GOOGLE_GENERATIVE_AI_API_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,9 @@ INGEST_HMAC_SECRET=             # Generate: node -e "console.log(require('crypto
 OPENSTATES_API_KEY=             # Free: https://openstates.org/accounts/signup/
 INGESTION_DAILY_LIMIT=50        # Max auto-ingested docs per day
 
+# ─── Eval Scoring (C16, optional) ───
+GOOGLE_GENERATIVE_AI_API_KEY=   # Gemini API key (https://aistudio.google.com/apikey). Without it, briefs get FK readability only; tone scoring is skipped.
+
 # ─── Email (optional) ───
 RESEND_API_KEY=                 # https://resend.com
 ADMIN_EMAIL=                    # Feed failure alerts + weekly digest recipient

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ npm install
 | `NEXT_PUBLIC_SUPABASE_URL` | Supabase project settings | Yes (database) |
 | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase project settings | Yes (database) |
 | `SUPABASE_SERVICE_ROLE_KEY` | Supabase project settings | Yes (API routes) |
-| `GOOGLE_GENERATIVE_AI_KEY` | [aistudio.google.com](https://aistudio.google.com) | No (eval only) |
+| `GOOGLE_GENERATIVE_AI_API_KEY` | [aistudio.google.com](https://aistudio.google.com) | No (eval only) |
 
 The app works without Supabase configured. Upload and summarization still function; results just won't be persisted.
 

--- a/docs/superpowers/plans/2026-04-21-c15-multi-provider-ai.md
+++ b/docs/superpowers/plans/2026-04-21-c15-multi-provider-ai.md
@@ -434,7 +434,7 @@ import { generateText, Output } from 'ai';
 import { z } from 'zod';
 import { infra } from '@/lib/ai/models';
 
-const hasGeminiKey = !!process.env.GOOGLE_GENERATIVE_AI_KEY;
+const hasGeminiKey = !!process.env.GOOGLE_GENERATIVE_AI_API_KEY;
 
 describe.skipIf(!hasGeminiKey)('Gemini Flash smoke test', () => {
   it('returns structured JSON matching a Zod schema', async () => {
@@ -461,7 +461,7 @@ describe.skipIf(!hasGeminiKey)('Gemini Flash smoke test', () => {
 });
 
 describe.skipIf(hasGeminiKey)('Gemini Flash without API key', () => {
-  it('skips when GOOGLE_GENERATIVE_AI_KEY is not set', () => {
+  it('skips when GOOGLE_GENERATIVE_AI_API_KEY is not set', () => {
     // This test documents that the smoke test is intentionally skipped in CI
     // when the Gemini API key is not configured.
     expect(hasGeminiKey).toBe(false);
@@ -476,7 +476,7 @@ Expected: 1 test passes (the "skips" documentation test), 1 test skipped.
 
 - [ ] **Step 3: Run with API key (local dev scenario)**
 
-Ensure `GOOGLE_GENERATIVE_AI_KEY` is set in `.env.local`, then:
+Ensure `GOOGLE_GENERATIVE_AI_API_KEY` is set in `.env.local`, then:
 Run: `npx vitest run tests/integration/ai-provider-smoke.test.ts`
 Expected: Smoke test passes, returns valid structured JSON.
 
@@ -588,6 +588,6 @@ Expected: No new errors. No references to Gemini or AI SDK in any production pag
 | Live site works end-to-end | Task 7 |
 | New provider module exports are importable | Task 4, Step 2 |
 | Gemini Flash returns structured JSON | Task 5, Step 3 |
-| Missing GOOGLE_GENERATIVE_AI_KEY produces clear error | Task 5, Step 2 |
+| Missing GOOGLE_GENERATIVE_AI_API_KEY produces clear error | Task 5, Step 2 |
 | No changes to existing anthropic.ts, pipeline.ts, prompts/ | Task 6, Step 6 |
 | Build succeeds | Task 6, Step 7 |

--- a/docs/superpowers/plans/2026-04-27-c16-civic-eval-agent.md
+++ b/docs/superpowers/plans/2026-04-27-c16-civic-eval-agent.md
@@ -622,7 +622,7 @@ Create `tests/integration/eval-tone.test.ts`:
 import { describe, it, expect } from 'vitest';
 import { evaluateTone } from '@/lib/eval/tone';
 
-const hasGeminiKey = !!process.env.GOOGLE_GENERATIVE_AI_KEY;
+const hasGeminiKey = !!process.env.GOOGLE_GENERATIVE_AI_API_KEY;
 
 describe.skipIf(!hasGeminiKey)('evaluateTone (Gemini Flash)', () => {
   it('scores plain-language civic text with high tone and jargon scores', async () => {
@@ -653,7 +653,7 @@ describe.skipIf(!hasGeminiKey)('evaluateTone (Gemini Flash)', () => {
 });
 
 describe.skipIf(hasGeminiKey)('evaluateTone without API key', () => {
-  it('skips when GOOGLE_GENERATIVE_AI_KEY is not set', () => {
+  it('skips when GOOGLE_GENERATIVE_AI_API_KEY is not set', () => {
     expect(hasGeminiKey).toBe(false);
   });
 });
@@ -722,7 +722,7 @@ export async function evaluateTone(briefText: string): Promise<ToneResult> {
 }
 ```
 
-- [ ] **Step 3: Run integration test (requires GOOGLE_GENERATIVE_AI_KEY)**
+- [ ] **Step 3: Run integration test (requires GOOGLE_GENERATIVE_AI_API_KEY)**
 
 ```bash
 npx vitest run tests/integration/eval-tone.test.ts
@@ -1445,7 +1445,7 @@ Create `scripts/eval-briefs.ts`:
  * Usage: npx tsx scripts/eval-briefs.ts [--dry-run] [--limit N]
  *
  * Requires: NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
- * Optional: GOOGLE_GENERATIVE_AI_KEY (for tone scoring; FK-only without it)
+ * Optional: GOOGLE_GENERATIVE_AI_API_KEY (for tone scoring; FK-only without it)
  */
 
 import { createClient } from '@supabase/supabase-js';
@@ -1465,7 +1465,7 @@ const args = process.argv.slice(2);
 const dryRun = args.includes('--dry-run');
 const limitIdx = args.indexOf('--limit');
 const limit = limitIdx !== -1 ? parseInt(args[limitIdx + 1], 10) : 100;
-const hasGemini = !!process.env.GOOGLE_GENERATIVE_AI_KEY;
+const hasGemini = !!process.env.GOOGLE_GENERATIVE_AI_API_KEY;
 
 async function main() {
   console.log(`Backfill eval scores (dry-run: ${dryRun}, limit: ${limit}, gemini: ${hasGemini})`);

--- a/docs/superpowers/specs/2026-04-19-c15-multi-provider-ai-design.md
+++ b/docs/superpowers/specs/2026-04-19-c15-multi-provider-ai-design.md
@@ -85,7 +85,7 @@ export const infra = {
 
 Adding a provider later: `npm install @ai-sdk/openai`, add one line. No interfaces, no adapters, no registry.
 
-Auth approach: Direct API keys (ANTHROPIC_API_KEY, GOOGLE_GENERATIVE_AI_KEY) in .env.local. Vercel AI Gateway is available as a future upgrade for cost dashboards and failover, but adds complexity we don't need yet. Switching to Gateway later is a 30-minute change (swap model imports for string slugs).
+Auth approach: Direct API keys (ANTHROPIC_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY) in .env.local. Vercel AI Gateway is available as a future upgrade for cost dashboards and failover, but adds complexity we don't need yet. Switching to Gateway later is a 30-minute change (swap model imports for string slugs).
 
 ### schemas.ts
 
@@ -159,12 +159,12 @@ const result = await generateText({
 
 | Name | Where | Who provisions | Required? |
 |------|-------|----------------|-----------|
-| `GOOGLE_GENERATIVE_AI_KEY` | .env.local, Vercel prod, Vercel preview | Manual (Google AI Studio) | Yes for eval features; app runs without it |
+| `GOOGLE_GENERATIVE_AI_API_KEY` | .env.local, Vercel prod, Vercel preview | Manual (Google AI Studio) | Yes for eval features; app runs without it |
 
 ### Graceful degradation
 
-If `GOOGLE_GENERATIVE_AI_KEY` is not set:
-- `infra` models throw a clear error when called: "GOOGLE_GENERATIVE_AI_KEY is not set. Eval features require a Gemini API key."
+If `GOOGLE_GENERATIVE_AI_API_KEY` is not set:
+- `infra` models throw a clear error when called: "GOOGLE_GENERATIVE_AI_API_KEY is not set. Eval features require a Gemini API key."
 - All existing functionality is unaffected (uses `anthropic.ts` directly, not `models.ts`)
 - CI tests that don't test eval pass without the key
 
@@ -208,11 +208,11 @@ If `GOOGLE_GENERATIVE_AI_KEY` is not set:
 | `infra models use google provider` | Eval workloads route to Gemini |
 | `schemas validate correct input` | Zod schemas accept well-formed data |
 | `schemas reject malformed input` | Zod schemas catch bad LLM output |
-| `missing GOOGLE_GENERATIVE_AI_KEY throws descriptive error` | Graceful degradation message |
+| `missing GOOGLE_GENERATIVE_AI_API_KEY throws descriptive error` | Graceful degradation message |
 
 ### Integration test (new file: `tests/integration/ai-provider-smoke.test.ts`)
 
-One test that calls Gemini Flash with a trivial prompt and validates structured JSON response. Skipped when `GOOGLE_GENERATIVE_AI_KEY` is not set (same pattern as Supabase tests in CI).
+One test that calls Gemini Flash with a trivial prompt and validates structured JSON response. Skipped when `GOOGLE_GENERATIVE_AI_API_KEY` is not set (same pattern as Supabase tests in CI).
 
 ### Existing tests
 
@@ -230,7 +230,7 @@ All existing unit/integration tests and E2E tests must pass with zero failures. 
 | 4 | Live site works: upload PDF, get brief, translate, verify | Manual browser test |
 | 5 | New provider module exports are importable | Unit test |
 | 6 | Gemini Flash returns structured JSON matching Zod schema | Integration smoke test |
-| 7 | Missing GOOGLE_GENERATIVE_AI_KEY produces clear error (not crash) | Unit test |
+| 7 | Missing GOOGLE_GENERATIVE_AI_API_KEY produces clear error (not crash) | Unit test |
 | 8 | No changes to existing anthropic.ts, pipeline.ts, or prompts/ | `git diff` inspection |
 | 9 | Build succeeds on Vercel (preview deploy) | Vercel preview URL |
 
@@ -260,7 +260,7 @@ Not applicable. This spec adds a module with no write paths. The `models.ts` fil
 | AI SDK adds bundle size | It is tree-shakeable; only imported providers are bundled. Verify with `next build` output. |
 | Gemini structured output differs from Anthropic | Zod schema validation catches shape mismatches at runtime. Integration smoke test validates. |
 | Zod dependency conflicts | Check for existing Zod usage (none currently). Pin to latest stable. |
-| GOOGLE_GENERATIVE_AI_KEY leaks | Same .env.local pattern as ANTHROPIC_API_KEY. Never committed. |
+| GOOGLE_GENERATIVE_AI_API_KEY leaks | Same .env.local pattern as ANTHROPIC_API_KEY. Never committed. |
 
 ---
 

--- a/docs/superpowers/specs/2026-04-25-c16-civic-eval-agent-design.md
+++ b/docs/superpowers/specs/2026-04-25-c16-civic-eval-agent-design.md
@@ -281,7 +281,7 @@ Two eval backfill runs simultaneously:
 - `@ai-sdk/google` (already installed via C15) -- for Gemini Flash
 - `ai` (already installed via C15) -- AI SDK core
 
-No new external services. No new env vars (GOOGLE_GENERATIVE_AI_KEY already configured for C15).
+No new external services. No new env vars (GOOGLE_GENERATIVE_AI_API_KEY already configured for C15).
 
 ---
 
@@ -308,7 +308,7 @@ No new external services. No new env vars (GOOGLE_GENERATIVE_AI_KEY already conf
 
 ### Integration Tests
 
-- `tone.ts`: Smoke test with Gemini Flash (skip when GOOGLE_GENERATIVE_AI_KEY not set, same pattern as C15).
+- `tone.ts`: Smoke test with Gemini Flash (skip when GOOGLE_GENERATIVE_AI_API_KEY not set, same pattern as C15).
 - Pipeline integration: Upload a brief, verify eval_overall_score is populated (requires Supabase + Gemini).
 
 ### E2E Tests (Playwright)

--- a/scripts/eval-briefs.ts
+++ b/scripts/eval-briefs.ts
@@ -4,7 +4,7 @@
  * Usage: npx tsx scripts/eval-briefs.ts [--dry-run] [--limit N]
  *
  * Requires: NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
- * Optional: GOOGLE_GENERATIVE_AI_KEY (for tone scoring; FK-only without it)
+ * Optional: GOOGLE_GENERATIVE_AI_API_KEY (for tone scoring; FK-only without it)
  */
 
 import { createClient } from '@supabase/supabase-js';
@@ -24,7 +24,7 @@ const args = process.argv.slice(2);
 const dryRun = args.includes('--dry-run');
 const limitIdx = args.indexOf('--limit');
 const limit = limitIdx !== -1 ? parseInt(args[limitIdx + 1], 10) : 100;
-const hasGemini = !!process.env.GOOGLE_GENERATIVE_AI_KEY;
+const hasGemini = !!process.env.GOOGLE_GENERATIVE_AI_API_KEY;
 
 async function main() {
   console.log(`Backfill eval scores (dry-run: ${dryRun}, limit: ${limit}, gemini: ${hasGemini})`);

--- a/tests/integration/ai-provider-smoke.test.ts
+++ b/tests/integration/ai-provider-smoke.test.ts
@@ -3,7 +3,7 @@ import { generateText, Output } from 'ai';
 import { z } from 'zod';
 import { infra } from '@/lib/ai/models';
 
-const hasGeminiKey = !!process.env.GOOGLE_GENERATIVE_AI_KEY;
+const hasGeminiKey = !!process.env.GOOGLE_GENERATIVE_AI_API_KEY;
 
 describe.skipIf(!hasGeminiKey)('Gemini Flash smoke test', () => {
   it('returns structured JSON matching a Zod schema', async () => {
@@ -30,7 +30,7 @@ describe.skipIf(!hasGeminiKey)('Gemini Flash smoke test', () => {
 });
 
 describe.skipIf(hasGeminiKey)('Gemini Flash without API key', () => {
-  it('skips when GOOGLE_GENERATIVE_AI_KEY is not set', () => {
+  it('skips when GOOGLE_GENERATIVE_AI_API_KEY is not set', () => {
     expect(hasGeminiKey).toBe(false);
   });
 });

--- a/tests/integration/eval-tone.test.ts
+++ b/tests/integration/eval-tone.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { evaluateTone } from '@/lib/eval/tone';
 
-const hasGeminiKey = !!process.env.GOOGLE_GENERATIVE_AI_KEY;
+const hasGeminiKey = !!process.env.GOOGLE_GENERATIVE_AI_API_KEY;
 
 describe.skipIf(!hasGeminiKey)('evaluateTone (Gemini Flash)', () => {
   it('scores plain-language civic text with high tone and jargon scores', async () => {
@@ -32,7 +32,7 @@ describe.skipIf(!hasGeminiKey)('evaluateTone (Gemini Flash)', () => {
 });
 
 describe.skipIf(hasGeminiKey)('evaluateTone without API key', () => {
-  it('skips when GOOGLE_GENERATIVE_AI_KEY is not set', () => {
+  it('skips when GOOGLE_GENERATIVE_AI_API_KEY is not set', () => {
     expect(hasGeminiKey).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

The `@ai-sdk/google` SDK reads `GOOGLE_GENERATIVE_AI_API_KEY` by default. The civic-brief code and docs used `GOOGLE_GENERATIVE_AI_KEY` (no `_API` suffix), causing tone scoring to fail silently if the project convention was followed: the gating check passes but the SDK call throws because the env var name doesn't match.

Verified in `node_modules/@ai-sdk/google/dist/index.js`:
```
environmentVariableName: "GOOGLE_GENERATIVE_AI_API_KEY"
```

This was caught while documenting the production setup steps for C16. No tone scoring has actually run against production briefs yet (env var was never set in Vercel), so no historical data is affected.

## Changes

- `scripts/eval-briefs.ts` — backfill gating check uses canonical name
- `tests/integration/eval-tone.test.ts` — test gating uses canonical name
- `tests/integration/ai-provider-smoke.test.ts` — test gating uses canonical name
- `CONTRIBUTING.md` — env var table updated
- `docs/superpowers/specs/2026-04-25-c16-civic-eval-agent-design.md` — historical record updated to canonical name
- `docs/superpowers/specs/2026-04-19-c15-multi-provider-ai-design.md` — same
- `docs/superpowers/plans/2026-04-27-c16-civic-eval-agent.md` — same
- `docs/superpowers/plans/2026-04-21-c15-multi-provider-ai.md` — same
- `.env.example` — variable was previously undocumented; now added under "Eval Scoring (C16, optional)"

## Verification

- 407/407 unit tests pass (no test count change)
- `grep -r GOOGLE_GENERATIVE_AI_KEY` returns zero matches across the repo
- Spec docs updated retroactively because they would otherwise propagate the old name to anyone re-reading them

## Test plan

- [ ] Set `GOOGLE_GENERATIVE_AI_API_KEY=AIza...` in `.env.local` from https://aistudio.google.com/apikey
- [ ] Run `npx tsx scripts/eval-briefs.ts --dry-run --limit 1` and confirm the script reports `gemini: true`
- [ ] Add the same var to Vercel production env, redeploy
- [ ] Upload a fresh brief in production and confirm tone badge populates within 30s

## NOT in scope

- Adding the actual key to Vercel (manual step Jatin will do)
- Backfilling existing briefs (separate task once key is live in prod)
- Fixing the duplicated eval blocks in pipeline + summarize route (noted in C16 retro as future cleanup)