### PR TITLE
fix(eval): auto-load .env.local in eval-briefs script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
+        "dotenv": "^17.4.2",
         "jsdom": "^29.0.2",
         "typescript": "^5.7.3",
         "vitest": "^4.1.4"
@@ -2140,6 +2141,19 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/entities": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
+    "dotenv": "^17.4.2",
     "jsdom": "^29.0.2",
     "typescript": "^5.7.3",
     "vitest": "^4.1.4"

--- a/scripts/eval-briefs.ts
+++ b/scripts/eval-briefs.ts
@@ -7,8 +7,11 @@
  * Optional: GOOGLE_GENERATIVE_AI_API_KEY (for tone scoring; FK-only without it)
  */
 
+import { config as loadEnv } from 'dotenv';
 import { createClient } from '@supabase/supabase-js';
 import { scoreBriefSync, scoreBriefFull } from '../src/lib/eval';
+
+loadEnv({ path: '.env.local', quiet: true });
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;


### PR DESCRIPTION
## Summary

The backfill script `scripts/eval-briefs.ts` reads env vars via bare `process.env`, so it doesn't pick up `.env.local` unless invoked with `npx tsx --env-file=.env.local ...`. Caught this while running the C16 backfill — easy to forget, easy to silently fall back to FK-only scoring without realizing.

Now the script loads `.env.local` itself via `dotenv`, so `npx tsx scripts/eval-briefs.ts --limit 50` works as documented in the script header.

## Changes

- Added `dotenv@^17.4.2` as a devDependency
- `scripts/eval-briefs.ts`: 3-line addition — `import { config as loadEnv } from 'dotenv'` plus `loadEnv({ path: '.env.local', quiet: true })` at the top
- `quiet: true` suppresses dotenv 17's verbose `injected env (8) from .env.local` log

## Verification

- `npx tsx scripts/eval-briefs.ts --dry-run --limit 1` works without the `--env-file` flag
- `gemini: true` confirms `GOOGLE_GENERATIVE_AI_API_KEY` is loaded
- 407/407 unit tests pass

## NOT in scope

- Other tsx scripts in `scripts/` that may have the same pattern (haven't audited)
- Auditing for env var leaks (the `quiet: true` flag prevents accidental key prefix logging from dotenv itself)