### PR TITLE
ci: CSP regression check on Vercel preview deploys (#63)

### DIFF
--- a/.github/workflows/csp-regression.yml
+++ b/.github/workflows/csp-regression.yml
@@ -1,0 +1,69 @@
+name: CSP Regression Check
+
+on:
+  deployment_status: {}
+
+jobs:
+  csp-check:
+    runs-on: ubuntu-latest
+
+    # Run only when a Vercel Preview deployment succeeds.
+    # The environment_url host check defensively skips production aliases
+    # (*.vercel.app with no branch slug) that sometimes fire with state=success
+    # and environment=Preview when a prod re-deploy is triggered from a branch.
+    if: |
+      github.event.deployment_status.state == 'success' &&
+      github.event.deployment.environment == 'Preview' &&
+      !contains(github.event.deployment_status.environment_url, 'civic-brief.vercel.app')
+
+    permissions:
+      contents: read
+      deployments: read
+
+    steps:
+      # Verify the bypass secret is present before doing any work.
+      # Without it every Playwright request returns 401 from Vercel Deployment
+      # Protection and the test trivially "passes" with no real assertions.
+      # See CONTRIBUTING.md for setup instructions.
+      - name: Verify bypass secret is set
+        run: |
+          if [ -z "${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}" ]; then
+            echo "::error::VERCEL_AUTOMATION_BYPASS_SECRET is not set. Add it to repository secrets (Settings > Secrets > Actions). See CONTRIBUTING.md for setup instructions."
+            exit 1
+          fi
+
+      # Check out the exact commit Vercel deployed, not the current HEAD of
+      # main. The PR may have additional commits since this deployment fired.
+      - name: Checkout deployment SHA
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.deployment.sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run CSP regression test
+        run: npx playwright test tests/e2e/csp.spec.ts --project=chromium
+        env:
+          E2E_BASE_URL: ${{ github.event.deployment_status.environment_url }}
+          # Read by tests/e2e/csp.spec.ts to inject the bypass header
+          # (x-vercel-protection-bypass + x-vercel-set-bypass-cookie) on every
+          # Playwright request, defeating Vercel Deployment Protection.
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report-csp
+          path: playwright-report/
+          retention-days: 7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,6 +169,14 @@ We take security seriously because civic misinformation is a democratic harm.
 - **HMAC authentication** on internal worker endpoints
 - **Privacy by design**: We never store uploaded documents, collect PII, or set tracking cookies
 
+### Automated CSP Regression Check
+
+Every PR triggers a Vercel preview deploy. After the preview is ready, a GitHub Actions workflow runs `tests/e2e/csp.spec.ts` against the preview URL. This check catches Content Security Policy regressions in a real browser before they reach production. The check exists because a prior CSP regression broke production hydration; verification against dev mode and curl missed this issue class entirely.
+
+**Maintainer setup**: This check requires a Vercel Protection Bypass for Automation token. Generate one in your Vercel Dashboard under Project Settings, Deployment Protection. Add it as the GitHub Actions secret `VERCEL_AUTOMATION_BYPASS_SECRET`. Contributors opening PRs from forks do not need to set this up; maintainers enable the preview after approving the PR.
+
+**Debugging a failed check**: Download the `playwright-report-csp` artifact from the failed GitHub Actions workflow run. Open `index.html` in the artifact in your browser to see the full Playwright report, including screenshots and network traces.
+
 ## Civic-Context Prompting
 
 This is what differentiates Civic Brief from generic summarization. Every prompt produces structured JSON answering:

--- a/docs/superpowers/specs/2026-05-08-csp-regression-ci-design.md
+++ b/docs/superpowers/specs/2026-05-08-csp-regression-ci-design.md
@@ -1,0 +1,115 @@
+# C63: CSP Regression CI Design Spec
+
+**Date:** 2026-05-08
+**Issue:** #63
+**Status:** Draft
+**Author:** Jatin + Engineer Agent
+
+---
+
+## Why
+
+PR #61 dropped `'unsafe-inline'` from the production `script-src` directive during CSP hardening. The change was verified against the dev server and via curl, neither of which exercises the production CSP in a real browser. Next.js RSC bootstrap emits inline scripts that the hardened directive blocked; hydration silently failed on every page in production for roughly two weeks. The regression surfaced only when an unrelated redeploy changed the environment.
+
+PR #62 added `tests/e2e/csp.spec.ts` as a regression guard, but the test runs locally on demand only. It does nothing to stop the same class of bug from shipping again. This spec turns that test into an automatic PR check against a production-built deployment.
+
+---
+
+## Goal
+
+Run `tests/e2e/csp.spec.ts` against the Vercel preview URL on every PR, and hard-fail the PR check if any assertion fails.
+
+---
+
+## Architecture and Data Flow
+
+```
+PR opened / pushed
+       |
+  [Vercel builds preview deployment]
+       |
+  [GitHub emits `deployment_status` event: state=success, environment=Preview]
+       |
+  [csp-regression.yml triggers]
+       |
+  [Workflow reads environment_url from event payload]
+       |
+  [Guard: skip if environment_url matches civic-brief.vercel.app (production alias)]
+       |
+  [Guard: exit 1 if VERCEL_AUTOMATION_BYPASS_SECRET is not set]
+       |
+  [Install Playwright + Chromium]
+       |
+  [Run: E2E_BASE_URL=<preview_url> npx playwright test tests/e2e/csp.spec.ts --project chromium]
+        (extraHTTPHeaders: { x-vercel-protection-bypass: <secret> } injected in csp.spec.ts)
+       |
+  [Pass / Fail -> GitHub check on PR]
+```
+
+### Why `deployment_status`, not `pull_request`
+
+`pull_request` events from forks run in the fork's context and cannot access repo secrets. The CSP bypass token is a secret. A workflow that silently skips on every external contribution is not a guardrail.
+
+`deployment_status` events run in the base repository's context regardless of fork origin. Secrets are available. The practical trade-off: fork PRs only get the check after a maintainer approves the Vercel preview deployment (standard OSS gate). That is acceptable; maintainer approval already gates the deploy itself.
+
+GitHub Actions docs: "Workflows that run in a pull_request event from a fork don't have access to secrets." `deployment_status` is exempt from this restriction because it fires in the base repo context.
+
+### Bypass auth
+
+Vercel deployment protection walls preview URLs by default. The bypass mechanism sends `x-vercel-protection-bypass: <VERCEL_AUTOMATION_BYPASS_SECRET>` as an HTTP header on every Playwright request. This is stateless; no cookie session is established. The header is injected via Playwright's `extraHTTPHeaders` in `playwright.config.ts` (or directly in `csp.spec.ts`) when `E2E_BASE_URL` is set and the bypass secret is present.
+
+Vercel docs on the bypass header: "Set the `x-vercel-protection-bypass` header to the value of your Bypass for Automation secret." ([vercel.com/docs/deployments/deployment-protection](https://vercel.com/docs/deployments/deployment-protection))
+
+---
+
+## Components
+
+| File | Change |
+|------|--------|
+| `.github/workflows/csp-regression.yml` | ADD. New workflow triggered by `deployment_status`. |
+| `tests/e2e/csp.spec.ts` | MODIFY. Inject `x-vercel-protection-bypass` header via `extraHTTPHeaders` when `E2E_BASE_URL` is set. |
+| `CONTRIBUTING.md` | MODIFY. One paragraph: note that CSP is checked automatically on every PR against the preview deploy, and that `VERCEL_AUTOMATION_BYPASS_SECRET` must be configured in GitHub repo secrets. |
+| This spec doc | ADD. |
+
+### Environment variables
+
+| Variable | Where to set | Who provisions |
+|----------|-------------|----------------|
+| `VERCEL_AUTOMATION_BYPASS_SECRET` | GitHub repo secrets (Actions) | Maintainer, from Vercel dashboard under Deployment Protection |
+
+The secret is NOT needed in `.env.local` and NOT needed in Vercel's own env vars. It lives only in GitHub Actions secrets.
+
+---
+
+## Failure Modes
+
+| Scenario | What happens |
+|----------|-------------|
+| `VERCEL_AUTOMATION_BYPASS_SECRET` not set in GitHub Actions | Workflow exits 1 immediately with message: "VERCEL_AUTOMATION_BYPASS_SECRET is not set. Add it to GitHub repo secrets." PR check is red. No test work runs. |
+| `environment_url` matches production alias `civic-brief.vercel.app` | Workflow skips with a logged warning. Prevents running the check against production on post-merge deploys. |
+| Vercel preview takes longer than usual to reach `state=success` | Not a workflow concern. GitHub does not emit `deployment_status` until Vercel reports success. The workflow starts only after the event fires. |
+| Preview URL returns 401 (bypass header missing or wrong secret) | Playwright `page.goto()` lands on Vercel's auth wall, not the app. Console CSP assertions pass vacuously; the `Content-Security-Policy` header assertion fails because the Vercel auth page does not set the app's CSP header. PR check is red. The failure message makes the root cause clear. |
+| CSP test fails because a legit code change broke hydration | PR check is red. That is the intended behavior. |
+| Chromium not available on runner | `npx playwright install --with-deps chromium` step fails before tests run. PR check is red with a clear install error. |
+
+---
+
+## Verification
+
+After merging, the check works correctly if all of the following are true:
+
+1. A new PR is opened. Vercel creates a preview. The `csp-regression` check appears on the PR alongside the existing `CI / test` check.
+2. The check passes green on a clean PR with no CSP changes.
+3. A test branch that manually strips `'unsafe-inline'` from the production `script-src` in `src/proxy.ts` causes the check to go red. (Reproduce the #61 class of bug; confirm the guard catches it.)
+4. GitHub Actions logs show the preview URL under test, the bypass header in use, and per-page pass/fail lines from Playwright.
+5. A fork PR from an external contributor shows the check as pending until a maintainer approves the Vercel preview deploy, then resolves to pass or fail.
+
+---
+
+## Out of Scope
+
+- Running the full E2E suite (`npx playwright test` without a file filter) against the preview. Only `tests/e2e/csp.spec.ts` runs in this workflow.
+- Replacing or modifying the existing `CI / test` job in `.github/workflows/ci.yml`. The dev-mode E2E job stays as-is.
+- A post-merge CSP check against the production URL. That is a separate decision (cron-based UptimeRobot or a `deployment_status` filter on the production environment).
+- Switching the CSP to nonce + `'strict-dynamic'`. Blocked on Next.js 16 + Turbopack auto-nonce reliability. See the comment in `src/proxy.ts`.
+- Playwright browsers other than Chromium. CSP enforcement behavior is consistent across engines for the assertions in this test.

--- a/tests/e2e/csp.spec.ts
+++ b/tests/e2e/csp.spec.ts
@@ -45,6 +45,14 @@ for (const path of PAGES) {
         /Content Security Policy directive/i.test(text) &&
         /script-src/i.test(text)
       ) {
+        // Vercel injects its collaboration widget (vercel.live/_next-live/...)
+        // on Preview deployments only. Our production CSP intentionally does
+        // not whitelist vercel.live — the script never loads in prod. Filter
+        // these preview-only third-party violations so the test stays focused
+        // on own-origin regressions like the #61 RSC bootstrap miss.
+        if (/https:\/\/vercel\.live\//.test(text)) {
+          return;
+        }
         violations.push(text);
       }
     });

--- a/tests/e2e/csp.spec.ts
+++ b/tests/e2e/csp.spec.ts
@@ -1,5 +1,19 @@
 import { test, expect } from '@playwright/test';
 
+// Vercel preview deployments are auth-walled by Deployment Protection. The
+// bypass header is only sent when the secret is present (no-op locally and
+// against public production). The set-bypass-cookie header asks Vercel to also
+// set a session cookie so navigation requests Playwright initiates outside
+// extraHTTPHeaders coverage still bypass the wall.
+const extraHTTPHeaders: Record<string, string> = process.env.VERCEL_AUTOMATION_BYPASS_SECRET
+  ? {
+      'x-vercel-protection-bypass': process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
+      'x-vercel-set-bypass-cookie': 'true',
+    }
+  : {};
+
+test.use({ extraHTTPHeaders });
+
 /**
  * Regression test for the C17/C18 CSP miss (issue #61).
  *


### PR DESCRIPTION
Closes #63.

## Why

PR #61 hardened the production CSP (dropped `'unsafe-inline'` from `script-src`) but verification was done via curl + dev mode. Neither exercised the production runtime in a real browser. RSC bootstrap inline scripts were silently blocked, hydration broke on every page in production, and the regression hid for two weeks until an unrelated redeploy surfaced it (PR #62 fix, see issue #61 retro).

PR #62 added `tests/e2e/csp.spec.ts` as a regression guard, but it ran locally on demand only. This PR turns it into an automatic guardrail on every PR.

## What

- New workflow `.github/workflows/csp-regression.yml` triggered by GitHub's `deployment_status` event. Filters to `state=success` AND `environment=Preview` AND defensive prod-alias skip.
- `tests/e2e/csp.spec.ts` injects `x-vercel-protection-bypass` + `x-vercel-set-bypass-cookie` headers via Playwright `extraHTTPHeaders` when `VERCEL_AUTOMATION_BYPASS_SECRET` is set. No-op locally and against public production.
- Hard-fails with a clear error if the secret is missing in repo settings (silent skip would recreate the exact problem we're fixing).
- `CONTRIBUTING.md` updated with maintainer setup notes.
- Design spec at `docs/superpowers/specs/2026-05-08-csp-regression-ci-design.md`.

## Why `deployment_status` instead of `pull_request`

`pull_request` events from forks have no access to repo secrets, so the bypass token would be missing and the check would silently skip on every external contribution. `deployment_status` events run in the base-repo context and have secret access, so fork PRs work correctly once a maintainer approves the Vercel preview deploy (acceptable OSS gate).

## Acceptance criteria (from #63)

- [x] New job in `.github/workflows/` (`csp-regression.yml`) that runs on PR-driven previews
- [x] Waits for Vercel preview (via `deployment_status` event), runs `tests/e2e/csp.spec.ts` against it, exits non-zero on failure
- [x] Documented in `CONTRIBUTING.md` (one-line note that CSP is checked automatically + maintainer setup)
- [x] Bypass mechanism wired up via `VERCEL_AUTOMATION_BYPASS_SECRET`

## Test plan

- [x] Local smoke test: `E2E_BASE_URL=https://civic-brief.vercel.app npx playwright test tests/e2e/csp.spec.ts --project=chromium` (5 tests, all passed in 6.4s against current prod)
- [x] `npm run typecheck` clean
- [x] `npm test` 407 tests pass (404 + 3 skipped, baseline match)
- [x] `npm run test:check` baseline gate passes
- [ ] On this PR: CSP regression check workflow appears in PR checks list, runs after Vercel preview is ready, goes green
- [ ] Optional follow-up: a throwaway branch that strips `'unsafe-inline'` from `src/proxy.ts` should turn the new check red, proving it catches the #61 class of bug

## Out of scope

- Running the full E2E suite against the preview (only `csp.spec.ts` for now)
- Replacing the existing dev-mode E2E job in `ci.yml`
- Production post-merge CSP check (separate decision)
- Switching CSP to nonce + `'strict-dynamic'` (blocked on Next.js 16 + Turbopack auto-nonce reliability, see `src/proxy.ts` comment)

## Setup required (already done before opening this PR)

`VERCEL_AUTOMATION_BYPASS_SECRET` set in repo Settings → Secrets → Actions, sourced from a Vercel Protection Bypass for Automation token.