### PR TITLE
fix: real HTTP 404 for unknown /showcase and /brief slugs (#59)

### DIFF
--- a/src/app/brief/[id]/page.tsx
+++ b/src/app/brief/[id]/page.tsx
@@ -2,6 +2,16 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import CivicBrief from '@/components/CivicBrief';
 import type { CivicContent, FeedbackType } from '@/lib/types';
+import { isValidUUID } from '@/lib/security';
+
+// Brief IDs are an open set (UUIDs from Supabase, plus the `demo`/`test-id` mocks).
+// Reject anything else at the metadata stage so the response is a real HTTP 404 instead
+// of the streamed soft-404 the page handler would otherwise emit. Valid-format-but-not-in-DB
+// still resolves through notFound() in the page body (acceptable soft-404; SEO is protected
+// by Next.js' noindex meta tag on streamed not-found pages).
+function isAllowedBriefSlug(id: string): boolean {
+  return id === 'demo' || id === 'test-id' || isValidUUID(id);
+}
 
 // Mock data for when Supabase is not configured
 const MOCK_BRIEF = {
@@ -69,6 +79,10 @@ interface PageProps {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { id } = await params;
+
+  if (!isAllowedBriefSlug(id)) {
+    notFound();
+  }
 
   if (id === 'demo' || id === 'test-id') {
     return {

--- a/src/app/showcase/[scenario]/page.tsx
+++ b/src/app/showcase/[scenario]/page.tsx
@@ -8,13 +8,16 @@ interface PageProps {
   params: Promise<{ scenario: string }>;
 }
 
-// Unknown slugs 404 before streaming starts, so the response code is actually 404
-// instead of a streamed soft-404 with status 200. See Next.js streaming status-code docs.
+// generateStaticParams + dynamicParams=false defines the closed slug set, so unknown
+// slugs 404 at the routing layer before streaming starts (real HTTP 404, not a
+// streamed soft-404 with status 200). force-dynamic ensures the valid slugs still
+// render with fresh Supabase data on each request, matching the grid page in page.tsx.
 export function generateStaticParams() {
   return scenarios.map((s) => ({ scenario: s.slug }));
 }
 
 export const dynamicParams = false;
+export const dynamic = 'force-dynamic';
 
 export async function generateMetadata({ params }: PageProps) {
   const { scenario: slug } = await params;

--- a/src/app/showcase/[scenario]/page.tsx
+++ b/src/app/showcase/[scenario]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from 'next/navigation';
-import { getScenarioBySlug } from '@/lib/showcase';
+import { getScenarioBySlug, scenarios } from '@/lib/showcase';
 import ScenarioHero from '@/components/ScenarioHero';
 import CivicBrief from '@/components/CivicBrief';
 import type { CivicContent } from '@/lib/types';
@@ -7,6 +7,14 @@ import type { CivicContent } from '@/lib/types';
 interface PageProps {
   params: Promise<{ scenario: string }>;
 }
+
+// Unknown slugs 404 before streaming starts, so the response code is actually 404
+// instead of a streamed soft-404 with status 200. See Next.js streaming status-code docs.
+export function generateStaticParams() {
+  return scenarios.map((s) => ({ scenario: s.slug }));
+}
+
+export const dynamicParams = false;
 
 export async function generateMetadata({ params }: PageProps) {
   const { scenario: slug } = await params;

--- a/tests/e2e/pages.spec.ts
+++ b/tests/e2e/pages.spec.ts
@@ -124,6 +124,11 @@ test.describe('Brief demo page', () => {
     await page.goto('/brief/demo');
     await checkA11y(page, 'Brief Demo');
   });
+
+  test('returns 404 for malformed brief id', async ({ page }) => {
+    const response = await page.goto('/brief/nonexistent');
+    expect(response?.status()).toBe(404);
+  });
 });
 
 test.describe('Language switching', () => {


### PR DESCRIPTION
## Summary
- Closes #59: `/showcase/<unknown-slug>` now returns HTTP 404 instead of a "soft-404" (status 200 + not-found UI streamed into the body).
- Also fixes the same latent bug on `/brief/<unknown-id>`, caught while investigating #59.
- Root cause: Next.js 16's streaming SSR commits the response status before the page handler's `notFound()` can take effect. The not-found UI renders correctly but the status stays at 200.

## What changed
- `src/app/showcase/[scenario]/page.tsx`: scenarios are a closed set of 5 hardcoded slugs, so `generateStaticParams` + `dynamicParams = false` lets Next.js 404 unknown slugs at the routing layer, before streaming begins.
- `src/app/brief/[id]/page.tsx`: brief IDs are an open set (Supabase UUIDs plus `demo`/`test-id` mocks). Format validation moved into `generateMetadata`, where `notFound()` fires before the response body is committed. Valid-format-but-not-in-DB still soft-404s — that's an acceptable trade-off documented inline.
- `tests/e2e/pages.spec.ts`: new regression test `returns 404 for malformed brief id`.

## Test plan
- [x] `npm test` — 404 passed + 3 skipped (unchanged from baseline)
- [x] `npx playwright test` — 94 passed + 2 skipped (was 92 + 2; +2 from the new 404 test running on chromium + mobile-chrome)
- [x] `npx tsc --noEmit` — clean
- [x] Both previously-failing showcase 404 tests now pass on both projects
- [x] No regressions in existing showcase / brief tests

## Trade-offs
- For `/brief/<valid-uuid-not-in-db>`: still emits a soft-404 (status 200, not-found UI, `<meta name="robots" content="noindex">`). The alternative is a DB lookup in the proxy on every brief load, which is not worth the latency cost for a rare case (deleted briefs). Documented inline.